### PR TITLE
Replace Cloud Deploy with kubectl apply for API deployment

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -157,18 +157,12 @@ steps:
     - "CLOUDSDK_CONTAINER_CLUSTER=${_GKE_CLUSTER_NAME}"
     - "CLOUDSDK_COMPUTE_REGION=$LOCATION"
 
-- name: 'google/cloud-sdk:latest'
+- name: "gcr.io/cloud-builders/kubectl"
   id: 'Deploy API'
-  entrypoint: 'bash'
-  args:
-  - -c
-  - |
-    set -e
-
-    gcloud deploy releases create "genai-${SHORT_SHA}-$(echo $BUILD_ID | cut -c1-7)" \
-      --delivery-pipeline=${_DELIVERY_PIPELINE_NAME} \
-      --region=$LOCATION \
-      --from-k8s-manifest=./k8s/api.yaml
+  args: ["apply", "-f", "./k8s/api.yaml", "--namespace=${_GKE_NAMESPACE}"]
+  env:
+    - "CLOUDSDK_CONTAINER_CLUSTER=${_GKE_CLUSTER_NAME}"
+    - "CLOUDSDK_COMPUTE_REGION=$LOCATION"
 
 - name: "gcr.io/cloud-builders/kubectl"
   id: 'Deploy Admin Panel'


### PR DESCRIPTION
## Summary
- `clouddeploy.googleapis.com` is not supported under Google Sovereign Controls, unlike `cloudbuild.googleapis.com` which only needed org-policy allowlisting. This blocks deployment to our sovereign-cloud environments.
- Every other component in `cloudbuild.yaml` (mongodb, meilisearch, vectordb, rag, admin panel, ingress) already deploys via a plain `kubectl apply` step rather than Cloud Deploy — only the API deployment step used `gcloud deploy releases create`.
- Cloud Deploy isn't providing any capability here beyond what `kubectl apply` already does for the rest of the pipeline: `require_approval` is `false`, there's a single-stage pipeline (no canary/progressive rollout), and each environment has its own independent pipeline rather than a promotion chain across environments.
- This replaces the Cloud Deploy step with `kubectl apply -f ./k8s/api.yaml`, matching the existing pattern, and removes the dependency entirely (all environments, not just sovereign ones).

## Test plan
- [ ] Confirm the Cloud Build trigger's substitutions no longer need `_DELIVERY_PIPELINE_NAME` (already removed on the infra side)
- [ ] Verify a build run against a non-sovereign environment (pub-dev) still deploys the API correctly via `kubectl apply`
- [ ] Coordinate merge timing with the infra-side Terraform change that removes the Cloud Deploy pipeline/target resources — this should merge before or at the same time, since builds off `main` will fail if the Terraform-side pipeline is destroyed while `cloudbuild.yaml` still references it